### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Copy site
+        run: |
+          mkdir -p public
+          cp -r docs/* public/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ python app.py
 ```
 
 Then open `http://localhost:5000` in your browser.
+
+## GitHub Pages
+
+A static version of the application is available under the `docs/` directory.
+It performs the API queries in the browser using JavaScript. The included
+GitHub Actions workflow (`.github/workflows/deploy.yml`) automatically deploys
+this directory to GitHub Pages whenever changes are pushed to the `main`
+branch. Enable GitHub Pages in the repository settings and select **GitHub
+Actions** as the source.

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,125 @@
+async function queryOpenFoodFactsByBarcode(barcode) {
+    const resp = await fetch(`https://world.openfoodfacts.org/api/v0/product/${barcode}.json`);
+    if (resp.ok) {
+        const data = await resp.json();
+        return data.product || {};
+    }
+    return {};
+}
+
+async function searchOpenFoodFacts(name) {
+    const params = new URLSearchParams({
+        search_terms: name,
+        search_simple: 1,
+        action: 'process',
+        json: 1
+    });
+    const resp = await fetch(`https://world.openfoodfacts.org/cgi/search.pl?${params.toString()}`);
+    if (resp.ok) {
+        const data = await resp.json();
+        if (data.products && data.products.length > 0) {
+            return data.products[0];
+        }
+    }
+    return {};
+}
+
+async function queryPubChem(ingredient) {
+    const resp = await fetch(`https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/${ingredient}/JSON`);
+    if (resp.ok) {
+        const data = await resp.json();
+        try {
+            const cid = data.PC_Compounds[0].id.id.cid;
+            return { cid: cid, source: resp.url };
+        } catch (e) {}
+    }
+    return {};
+}
+
+function buildJson(productData, ingredientsDetails) {
+    const result = {
+        data_source: 'Product Database Import',
+        import_date: new Date().toISOString().split('T')[0],
+        version: '1.0',
+        products: [],
+        ingredients: [],
+        health_effects: []
+    };
+
+    const productEntry = {
+        barcode: productData.id || '',
+        name: productData.product_name || '',
+        brand: productData.brands || '',
+        category: productData.categories || '',
+        description: productData.generic_name || '',
+        status: 'active',
+        is_dummy: false,
+        sources: ['OpenFoodFacts'],
+        regulatory_claims: '',
+        active_ingredients: [],
+        inactive_ingredients: []
+    };
+
+    for (const ing of ingredientsDetails) {
+        const ingEntry = {
+            name: ing.name,
+            function: '',
+            sources: ['OpenFoodFacts']
+        };
+        productEntry.inactive_ingredients.push(ingEntry);
+
+        const ingredientItem = {
+            name: ing.name,
+            scientific_name: '',
+            cas_number: '',
+            category: '',
+            safety_rating: 'unknown',
+            description: '',
+            sources: ['OpenFoodFacts'],
+            health_effects: []
+        };
+        if (ing.pubchem) {
+            ingredientItem.sources.push(ing.pubchem.source);
+        }
+        result.ingredients.push(ingredientItem);
+    }
+
+    result.products.push(productEntry);
+    return result;
+}
+
+async function handleForm(event) {
+    event.preventDefault();
+    const form = event.target;
+    const name = form.product_name.value.trim();
+    const barcode = form.barcode.value.trim();
+    let product = {};
+    if (barcode) {
+        product = await queryOpenFoodFactsByBarcode(barcode);
+    } else if (name) {
+        const searchResult = await searchOpenFoodFacts(name);
+        if (searchResult && searchResult.id) {
+            product = await queryOpenFoodFactsByBarcode(searchResult.id);
+        }
+    }
+    if (product && Object.keys(product).length > 0) {
+        const ingredients = [];
+        for (const ing of product.ingredients || []) {
+            const ingName = ing.text;
+            const detail = { name: ingName };
+            const pubchem = await queryPubChem(ingName);
+            if (Object.keys(pubchem).length) detail.pubchem = pubchem;
+            ingredients.push(detail);
+        }
+        const data = buildJson(product, ingredients);
+        document.getElementById('results').textContent = JSON.stringify(data, null, 2);
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const dl = document.getElementById('download');
+        dl.href = url;
+        dl.style.display = 'inline';
+        document.getElementById('result-section').style.display = 'block';
+    }
+}
+
+document.getElementById('search-form').addEventListener('submit', handleForm);

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+    <title>Product & Ingredient Aggregator</title>
+    <style>
+        textarea { width: 100%; height: 300px; }
+    </style>
+</head>
+<body>
+    <h1>Product & Ingredient Aggregator</h1>
+    <form id="search-form">
+        <label>Product Name:</label>
+        <input type="text" name="product_name">
+        <br>
+        <label>Barcode:</label>
+        <input type="text" name="barcode">
+        <br>
+        <button type="submit">Search</button>
+    </form>
+    <div id="result-section" style="display:none;">
+        <h2>Results</h2>
+        <pre id="results"></pre>
+        <a id="download" href="#" style="display:none;">Download JSON</a>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create static frontend in `docs/` with JS to call public APIs directly
- add GitHub Actions workflow to deploy `docs/` to Pages
- document GitHub Pages usage in README

## Testing
- `python -m py_compile app.py hello.py`

------
https://chatgpt.com/codex/tasks/task_e_687435cf4e308328a0cfbd4200ca2c41