### PR TITLE
Fix GH Pages workflow for artifact action v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Copy site
@@ -27,7 +27,7 @@ jobs:
           mkdir -p public
           cp -r docs/* public/
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: public
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary
- update checkout action to v4
- upgrade upload-pages-artifact to v2 so builds don't fail

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_687437e69ffc8328a320bd2ca1c64d4a