### PR TITLE
Improve network error handling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,9 @@
         <br>
         <button type="submit">Search</button>
     </form>
+    {% if error %}
+        <p style="color:red;">{{ error }}</p>
+    {% endif %}
     {% if data %}
         <h2>Results</h2>
         <pre>{{ data | tojson(indent=2) }}</pre>


### PR DESCRIPTION
## Summary
- handle network errors in all API queries
- show an error on the results page when no data could be fetched

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687929272e408328be18a71f4022f7e3